### PR TITLE
Have the bluetooth applet override system tray icons

### DIFF
--- a/files/usr/share/cinnamon/applets/bluetooth@cinnamon.org/applet.js
+++ b/files/usr/share/cinnamon/applets/bluetooth@cinnamon.org/applet.js
@@ -192,17 +192,21 @@ PinNotification.prototype = {
     }
 }
 
-function MyApplet(orientation, panel_height) {
-    this._init(orientation, panel_height);
+function MyApplet(metadata, orientation, panel_height) {
+    this._init(metadata, orientation, panel_height);
 }
 
 MyApplet.prototype = {
     __proto__: Applet.TextIconApplet.prototype,
 
-    _init: function(orientation, panel_height) {        
+    _init: function(metadata, orientation, panel_height) {        
         Applet.TextIconApplet.prototype._init.call(this, orientation, panel_height);
         
-        try {                                
+        try {
+            this.metadata = metadata;
+            Main.systrayManager.registerRole("bluetooth", metadata.uuid);
+            Main.systrayManager.registerRole("bluetooth-manager", metadata.uuid);
+            
             this.menuManager = new PopupMenu.PopupMenuManager(this);
             this.menu = new Applet.AppletPopupMenu(this, orientation);
             this.menuManager.addMenu(this.menu);            
@@ -539,10 +543,14 @@ MyApplet.prototype = {
 
     _cancelRequest: function() {
         this._source.destroy();
+    },
+    
+    on_applet_removed_from_panel: function() {
+        Main.systrayManager.unregisterId(this.metadata.uuid);
     }
 };
 
 function main(metadata, orientation, panel_height) {  
-    let myApplet = new MyApplet(orientation, panel_height);
+    let myApplet = new MyApplet(metadata, orientation, panel_height);
     return myApplet;      
 }


### PR DESCRIPTION
This pull request is in conjunction with https://github.com/linuxmint/Cinnamon/pull/2843.
